### PR TITLE
Fix a typo: BU -> NEU

### DIFF
--- a/EC500/index-spring-2018.html
+++ b/EC500/index-spring-2018.html
@@ -35,7 +35,7 @@
           Schedule
         </h3>
           BU: Tue, Thu 1:30PM - 3:15PM @ PHO 205 at BU <br>
-          BU: Tue, Fri 1:35PM - 3:15PM @ Ryder Hall room 431 <br>
+          NEU: Tue, Fri 1:35PM - 3:15PM @ Ryder Hall room 431 <br>
         <!--h3><a name="announcements" class="anchor" href="#announcements"><span class="octicon octicon-link"></span></a>
             Announcements
           </h3-->


### PR DESCRIPTION
The location should be `NEU` rather than `BU`. fix a typo.

Fix: https://github.com/okrieg/okrieg.github.io/issues/15